### PR TITLE
Fix #68: Do strict testing for null | undefined on selected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,9 @@ out
 .nuxt
 dist
 
+# esbuild temp files
+tsconfig_esbuild.json
+
 # Gatsby files
 .cache/
 # Comment in the public line in if your project uses Gatsby and not Next.js

--- a/examples/optionpopup.mjs
+++ b/examples/optionpopup.mjs
@@ -1,0 +1,61 @@
+import { ConsoleManager, Button, ConfirmPopup, OptionPopup } from "../dist/esm/ConsoleGui.mjs"
+
+
+const opt = {
+    title: "Popup Test",
+    layoutOptions: {
+        type: "single",
+    },
+    logLocation: "popup",
+    enableMouse: true
+}
+
+const GUI = new ConsoleManager(opt)
+
+GUI.on("exit", () => {
+    closeApp()
+})
+
+GUI.on("keypressed", (key) => {
+    switch (key.name) {
+    case "q":
+        new ConfirmPopup({
+            id: "popupQuit", 
+            title: "Are you sure you want to quit?"
+        }).show().on("confirm", () => closeApp())
+        break
+    default:
+        break
+    }
+})
+
+const closeApp = () => {
+    console.clear()
+    process.exit()
+}
+
+const style1 = {
+    borderColor: "green",
+    color: "green",
+}
+
+const btnProps = {
+    id: "btnOpen", 
+    text: "Open a popup", 
+    x: 10, 
+    y: 15, 
+    style: style1,
+}
+
+const button = new Button(btnProps)
+button.on("click", () => {
+    new OptionPopup({
+        id: "testPopup",
+        title: "Choose an option",
+        options: [1, "string", 3],
+        selected: "",
+    }).show()
+    GUI.refresh()
+})
+
+GUI.refresh()

--- a/src/components/widgets/OptionPopup.ts
+++ b/src/components/widgets/OptionPopup.ts
@@ -76,7 +76,7 @@ export class OptionPopup extends EventEmitter {
         if (!id) throw new Error("OptionPopup id is required")
         if (!title) throw new Error("OptionPopup title is required")
         if (!options) throw new Error("OptionPopup options is required")
-        if (!selected) throw new Error("OptionPopup selected is required")
+        if (selected === undefined || selected === null) throw new Error("OptionPopup selected is required")
         super()
         /** @const {ConsoleManager} CM the instance of ConsoleManager (singleton) */
         this.CM = new ConsoleManager()


### PR DESCRIPTION
This PR addresses #68 by changing the following line:

https://github.com/Elius94/console-gui-tools/blob/6e68febe7cfa364b236d48f7ec110e1fe41fd2d1/src/components/widgets/OptionPopup.ts#L79

to 

https://github.com/Compositr/console-gui-tools/blob/abd0ee04aa859e74864d7e5a2cf47276fa3b8f91/src/components/widgets/OptionPopup.ts#L79

```ts
        if (selected === undefined || selected === null) throw new Error("OptionPopup selected is required")
```

This strictly checks for null | undefined fixing the behaviour described in #68